### PR TITLE
LMDB: Set the page size to 16K

### DIFF
--- a/src/bcselect_lmdb.c
+++ b/src/bcselect_lmdb.c
@@ -109,6 +109,8 @@ static bool open(bcsel_db* self) {
         return lmdb_fail("Failed to create lmdb environment", result);
     if (result = mdb_env_set_maxdbs(this->m_env, 32))
         return lmdb_fail("Failed to set max number of dbs", result);
+    if (result = mdb_env_set_pagesize(this->m_env, 0x4000)) //16K page size
+        return lmdb_fail("Failed to set page size", result);
     if (result = mdb_env_open(this->m_env, this->path, MDB_RDONLY, 0644))
         return lmdb_fail("Failed to open lmdb environment", result);
 

--- a/src/lmdb.h
+++ b/src/lmdb.h
@@ -884,6 +884,15 @@ int  mdb_env_get_fd(MDB_env *env, mdb_filehandle_t *fd);
 	 */
 int  mdb_env_set_mapsize(MDB_env *env, mdb_size_t size);
 
+	/** @brief Set the size of DB pages in bytes.
+	 *
+	 * The size defaults to the OS page size. Smaller or larger values may be
+	 * desired depending on the size of keys and values being used. Also, an
+	 * explicit size may need to be set when using filesystems like ZFS which
+	 * don't use the OS page size.
+	 */
+int  mdb_env_set_pagesize(MDB_env *env, int size);
+
 	/** @brief Set the maximum number of threads/reader slots for the environment.
 	 *
 	 * This defines the number of slots in the lock table that is used to track readers in the

--- a/src/mdb.c
+++ b/src/mdb.c
@@ -10598,6 +10598,19 @@ mdb_env_get_fd(MDB_env *env, mdb_filehandle_t *arg)
 	return MDB_SUCCESS;
 }
 
+int ESECT
+mdb_env_set_pagesize(MDB_env* env, int size)
+{
+    if (!env || env->me_map)
+        return EINVAL;
+    if (size > MAX_PAGESIZE || size < 256)
+        return EINVAL;
+    if (size & (size - 1))
+        return EINVAL;
+    env->me_os_psize = size;
+    return MDB_SUCCESS;
+}
+
 /** Common code for #mdb_stat() and #mdb_env_stat().
  * @param[in] env the environment to operate in.
  * @param[in] db the #MDB_db record containing the stats to return.


### PR DESCRIPTION
@hyc

Chain synced without issues. Blockchain turned out a bit smaller (86 GiB vs 90 GiB).

bc_selector performance increased by a factor of 4 on both SSD and HDD.